### PR TITLE
Add support for plain text only emails

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -352,6 +352,7 @@ SYSLOG_FACILITY=
 EMAIL_SENDER=
 EMAIL_CHARSET=$(locale charmap 2>/dev/null)
 EMAIL_THREADING=
+EMAIL_PLAINTEXT_ONLY=
 
 # irc configs
 IRC_NICKNAME=
@@ -2093,6 +2094,8 @@ SENT_SYSLOG=$?
 # -----------------------------------------------------------------------------
 # send the email
 
+if [[ "${EMAIL_PLAINTEXT_ONLY}" == "YES" ]]; then
+
 send_email <<EOF
 To: ${to_email}
 Subject: ${host} ${status_message} - ${name//_/ } - ${chart}
@@ -2233,6 +2236,45 @@ Content-Transfer-Encoding: 8bit
 </html>
 --multipart-boundary--
 EOF
+
+else
+
+send_email <<EOF
+To: ${to_email}
+Subject: ${host} ${status_message} - ${name//_/ } - ${chart}
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="multipart-boundary"
+${email_thread_headers}
+
+This is a MIME-encoded multipart message
+
+--multipart-boundary
+Content-Type: text/plain; encoding=${EMAIL_CHARSET}
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+
+${host} ${status_message}
+
+${alarm} ${info}
+${raised_for}
+
+Chart   : ${chart}
+Family  : ${family}
+Severity: ${severity}
+URL     : ${goto_url}
+Source  : ${src}
+Date    : ${date}
+Notification generated on ${host}
+
+Evaluated Expression :  ${calc_expression}
+Expression Variables :  ${calc_param_values}
+
+The host has ${total_warnings} WARNING and ${total_critical} CRITICAL alarm(s) raised.
+
+--multipart-boundary--
+EOF
+
+fi
 
 SENT_EMAIL=$?
 

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -221,6 +221,11 @@ DEFAULT_RECIPIENT_EMAIL="root"
 # below if you want to disable it.
 #EMAIL_THREADING="NO"
 
+# By default, netdata sends HTML and Plain Text emails, some clients
+# do not parse HTML emails such as command line clients.
+# To make emails readable in these clients, you can configure netdata
+# to not send HTML but Plain Text only emails.
+#EMAIL_PLAINTEXT_ONLY="YES"
 
 #------------------------------------------------------------------------------
 # pushover (pushover.net) global notification options


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes https://github.com/netdata/netdata/issues/6458
##### Component Name
Email alarms notifications
##### Additional Information
To enable the functionality add `EMAIL_PLAINTEXT_ONLY="YES"` in `health_alarm_notify.conf`
